### PR TITLE
Improve comment formatting in home page examples

### DIFF
--- a/content/index.smd
+++ b/content/index.smd
@@ -22,9 +22,9 @@
     "package-schema": 
       \\root = Package
       \\
-      \\///A Semantic Versioning version string.
+      \\/// A Semantic Versioning version string.
       \\@v = bytes,
-      \\///A valid SPDX expression.
+      \\/// A valid SPDX expression.
       \\@spdx = bytes,
       \\
       \\struct Package {
@@ -56,7 +56,7 @@
       \\  do: @action,
       \\  sender: bytes,
       \\  roles: [bytes],
-      \\  ///Optional metadata. 
+      \\  /// Optional metadata. 
       \\  extra: ?map[bytes],
       \\}
       \\


### PR DESCRIPTION
Now examples look a bit more polished and professional.

I noticed this after seeing the website was shared [on Reddit](https://old.reddit.com/r/programming/comments/1fwwmwq/ziggy_data_language/).